### PR TITLE
Feat/get usdc jpyc rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "11.1.0",
     "@testing-library/user-event": "12.1.10",
+    "anyswap-fetcher": "^0.2.4",
     "chroma-js": "2.1.2",
     "dotenv": "^16.0.0",
     "flatpickr": "4.6.9",

--- a/src/components/ExchangeRate/index.js
+++ b/src/components/ExchangeRate/index.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+import Pair from "../../lib/Pair";
+
+function ExchangeRate() {
+  const JPYC_ADDRESS = "0x6ae7dfc73e0dde2aa99ac063dcf7e8a63265108c";
+  const USDC_ADDRESS = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174";
+  const rpcNode = "https://polygon-rpc.com/";
+
+  const pair = new Pair(USDC_ADDRESS, JPYC_ADDRESS, rpcNode);
+
+  const [exchangeRate, setExchangeRate] = useState(0);
+
+  /* Round down exchange rate at the second decimal places.
+   * @param {number} _exchangeRate - Exchange rate to be rounded down.
+   */
+  function formatExchangeRate(_exchangeRate) {
+    // Input: 122.818747
+    return Math.ceil(_exchangeRate * 100) / 100;
+  }
+
+  useEffect(() => {
+    pair.getExchangeRate().then((rate) => {
+      const roundedRate = formatExchangeRate(rate);
+      setExchangeRate(roundedRate);
+    });
+  });
+
+  const renderExchangeRate = () => {
+    const isFetched = exchangeRate !== 0;
+    const el = <> USDC/JPYC: {exchangeRate}</>;
+    return <>{isFetched ? el : ""}</>;
+  };
+
+  return <> {renderExchangeRate()}</>;
+}
+
+export default ExchangeRate;

--- a/src/components/ExchangeRate/index.js
+++ b/src/components/ExchangeRate/index.js
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 import Pair from "../../lib/Pair";
 
 function ExchangeRate() {
-  const JPYC_ADDRESS = "0x6ae7dfc73e0dde2aa99ac063dcf7e8a63265108c";
   const USDC_ADDRESS = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174";
-  const rpcNode = "https://polygon-rpc.com/";
+  const JPYC_ADDRESS = "0x6ae7dfc73e0dde2aa99ac063dcf7e8a63265108c";
+  const RPC_NODE = "https://polygon-rpc.com/";
 
-  const pair = new Pair(USDC_ADDRESS, JPYC_ADDRESS, rpcNode);
+  const pair = new Pair(USDC_ADDRESS, JPYC_ADDRESS, RPC_NODE);
 
   const [exchangeRate, setExchangeRate] = useState(0);
 

--- a/src/examples/Navbars/DefaultNavbar/index.js
+++ b/src/examples/Navbars/DefaultNavbar/index.js
@@ -43,6 +43,9 @@ import DefaultNavbarMobile from "examples/Navbars/DefaultNavbar/DefaultNavbarMob
 // Material Kit 2 PRO React base styles
 import breakpoints from "assets/theme/base/breakpoints";
 
+// Self-made components
+import ExchangeRate from "components/ExchangeRate";
+
 function DefaultNavbar({ brand, routes, transparent, light, action, sticky, relative, center }) {
   const [dropdown, setDropdown] = useState("");
   const [dropdownEl, setDropdownEl] = useState("");
@@ -478,6 +481,15 @@ function DefaultNavbar({ brand, routes, transparent, light, action, sticky, rela
           >
             <MKTypography variant="button" fontWeight="bold" color={light ? "white" : "dark"}>
               {brand}
+            </MKTypography>
+          </MKBox>
+          <MKBox
+            lineHeight={1}
+            py={transparent ? 1.5 : 0.75}
+            pl={relative || transparent ? 0 : { xs: 0, lg: 1 }}
+          >
+            <MKTypography variant="button" fontWeight="regular" color={light ? "white" : "dark"}>
+              <ExchangeRate />
             </MKTypography>
           </MKBox>
           <MKBox

--- a/src/lib/Pair.js
+++ b/src/lib/Pair.js
@@ -1,0 +1,18 @@
+import { V2Fetcher } from "anyswap-fetcher";
+
+class Pair {
+  constructor(token0Addr, token1Addr, rpcNode) {
+    this.token0Addr = token0Addr;
+    this.token1Addr = token1Addr;
+    this.rpcNode = rpcNode;
+  }
+
+  async getExchangeRate() {
+    const quickSwap = new V2Fetcher(this.token0Addr, this.token1Addr, this.rpcNode, "QUICK");
+    const rate = await quickSwap.fetchExchangeRate();
+
+    return rate;
+  }
+}
+
+export default Pair;


### PR DESCRIPTION
resolve https://github.com/UnofficialClubJPYC/jpyc.fun/issues/20

## やったこと
- USDC/JPYC価格を取得するコンポーネント、クラスを追加
  - 一番流動性の高いQuickSwapでの価格を持ってきています。
  - 使用ライブラリ - [anyswap-fetcher](https://github.com/foxytanuki/anyswap-fetcher)
- 試験的に `DefaultNavBar` に表示

## やっていないこと
- [ ] UIの調整(後述)

## 相談したいこと
- 価格を表示する場所
  - issueの「メニューバー」＝ NavBar と解釈して、表示箇所を模索しましたがしっくり来る所が見当たらず、とりあえず仮置きしました。デザイン案あれば共有願いたいです。
    - <img width="1175" alt="Screen Shot 2022-02-18 at 1 52 25" src="https://user-images.githubusercontent.com/45069709/154530772-b2ddf355-f848-4598-85cf-2a094d18cc09.png">

  - [JPYC Info](https://github.com/foxytanuki/jpyc-info) のTopBarのような情報を表示するだけのComponentを設置する方法もありそうです。
    - <img width="1171" alt="Screen Shot 2022-02-18 at 1 43 39" src="https://user-images.githubusercontent.com/45069709/154529583-c8be407e-d419-4909-9550-77c44e4dfa3b.png">
